### PR TITLE
SSO redirect

### DIFF
--- a/lang/en/auth_userkey.php
+++ b/lang/en/auth_userkey.php
@@ -39,3 +39,5 @@ $string['redirecturl_desc'] = 'Optionally you can redirect users to this URL aft
 $string['incorrectredirecturl'] = 'You should provide valid URL';
 $string['userkey:generatekey'] = 'Generate login user key';
 $string['pluginisdisabled'] = 'The userkey authentication plugin is disabled.';
+$string['ssourl'] = 'URL of SSO host';
+$string['ssourl_desc'] = 'URL of the SSO host to redirect users to. If defined users will be redirected here on login instead of the Moodle Login page';

--- a/settings.html
+++ b/settings.html
@@ -56,6 +56,13 @@ $fields = get_auth_plugin('userkey')->get_allowed_mapping_fields();
             <?php if (isset($err[$field])) { echo $OUTPUT->notification($err[$field], 'notifyfailure'); } ?>
             <?php print_string($field.'_desc', 'auth_userkey') ?></td>
     </tr>
+    <tr valign="top">
+        <?php $field = 'ssourl' ?>
+        <td align="right"><label for="<?php echo $field ?>"><?php print_string($field, 'auth_userkey') ?></label></td>
+        <td><input type="text" size="60" name="<?php echo $field ?>" value="<?php print $config->$field ?>" placeholder=""><br>
+            <?php if (isset($err[$field])) { echo $OUTPUT->notification($err[$field], 'notifyfailure'); } ?>
+            <?php print_string($field.'_desc', 'auth_userkey') ?></td>
+    </tr>
     <!--UNCOMMENT FOLLOWING WHEN IMPLEMENT USER CREATION.-->
     <!--<tr valign="top">-->
         <!--<?php $field = 'createuser' ?>-->

--- a/tests/auth_plugin_test.php
+++ b/tests/auth_plugin_test.php
@@ -499,6 +499,7 @@ class auth_plugin_userkey_testcase extends advanced_testcase {
         $formconfig->keylifetime = 100;
         $formconfig->iprestriction = 0;
         $formconfig->redirecturl = 'http://google.com/';
+        $formconfig->ssourl = 'http://google.com/';
 
         $this->auth->process_config($formconfig);
 
@@ -706,6 +707,63 @@ class auth_plugin_userkey_testcase extends advanced_testcase {
         $redirect = @$this->auth->user_login_userkey();
 
         $this->assertEquals('http://test.com/course/index.php?id=12&key=134', $redirect);
+    }
+
+    /**
+     * Test that login page hook redirects correctly.
+     */
+    public function test_loginpage_hook_redirects_correctly() {
+        global $SESSION;
+
+        $SESSION->enrolkey_skipsso = 0;
+        set_config('ssourl', 'http://google.com', 'auth_userkey');
+        $this->auth = new auth_plugin_userkey();
+
+        $userredirect = $this->auth->should_login_redirect();
+        $this->assertEquals($userredirect, true);
+
+    }
+
+    /**
+     * Test that Moodle login page is displayed if url param is set correctly.
+     */
+    public function test_login_page_displays_correctly_url_param_set() {
+        global $SESSION;
+
+        $SESSION->enrolkey_skipsso = 1;
+        set_config('ssourl', 'http://google.com', 'auth_userkey');
+        $this->auth = new auth_plugin_userkey();
+        $userredirect = $this->auth->should_login_redirect();
+        $this->assertEquals($userredirect, false);
+
+    }
+
+    /**
+     * Test that Moodle login page is displayed if no redirect url and no param is set.
+     */
+    public function test_login_page_displays_correctly() {
+        global $SESSION;
+
+        $SESSION->enrolkey_skipsso = 0;
+        set_config('ssourl', '', 'auth_userkey');
+        $this->auth = new auth_plugin_userkey();
+        $userredirect = $this->auth->should_login_redirect();
+        $this->assertEquals($userredirect, false);
+
+    }
+
+    /**
+     * Test that Moodle login page is displayed if no redirect url, but param is set.
+     */
+    public function test_login_page_displays_correctly_param_set() {
+        global $SESSION;
+
+        $SESSION->enrolkey_skipsso = 1;
+        set_config('ssourl', '', 'auth_userkey');
+        $this->auth = new auth_plugin_userkey();
+        $userredirect = $this->auth->should_login_redirect();
+        $this->assertEquals($userredirect, false);
+
     }
 
 }

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die;
 
-$plugin->version   = 2016081600;        // The current plugin version (Date: YYYYMMDDXX)
+$plugin->version   = 2016081604;        // The current plugin version (Date: YYYYMMDDXX)
 $plugin->release   = 2016081600;        // Match release exactly to version.
 $plugin->requires  = 2015051100;        // Requires this Moodle version.
 $plugin->component = 'auth_userkey';    // Full name of the plugin (used for diagnostics).


### PR DESCRIPTION
Add functionality via plugin config to stop users from accessing the Moodle login page and instead redirect them to the SSO "host". The URL to redirect to can be set in the Plugin config.
Also add the option for users to override this redirect and to access the regular Moodle Login page by useing the query parameter: ?enrolkey_skipsso=on